### PR TITLE
Html: Allow concatenate arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,21 @@ echo 'Registered user: ' . $username;
 
 Use:
 ```php
-echo 'Registered user: ' . \JakubBoucek\Escape\Escape::html($username);
+use JakubBoucek\Escape\Escape;
+
+echo 'Registered user: ' . Escape::html($username);
+```
+
+You can use shortcut by aliasing too:
+```php
+use JakubBoucek\Escape\Escape as E;
+
+echo 'Registered user: ' . E::html($username);
 ```
 
 ## CSS specifics
 
-In few cases you cannot use `\JakubBoucek\Escape\Escape::css($cssColor)` to escape
+In few cases you cannot use `Escape::css($cssColor)` to escape
 some known format, because standard escaping is broke CSS format. Class `EscapeCss` has prepared
 limited set of known propetries with specefics format:
 
@@ -48,7 +57,9 @@ limited set of known propetries with specefics format:
 Sanitize value od CSS `color` property to safe format, example:
 
 ```php
-echo '<style>color: ' . \JakubBoucek\Escape\EscapeCss::color($cssColor) . ';</style>';
+use JakubBoucek\Escape\EscapeCss;
+
+echo '<style>color: ' . EscapeCss::color($cssColor) . ';</style>';
 ```
 
 It's prevent attact by escaping color value context.
@@ -56,6 +67,20 @@ It's prevent attact by escaping color value context.
 ## Safe HTML content
 
 Package supports escaping HTML with included [safe HTML content](https://doc.nette.org/en/3.1/html-elements).
+
+Usage:
+```php
+use JakubBoucek\Escape\Escape;
+use Nette\Utils\Html; 
+
+$avatarUrl = 'http:/example.com/avatar.png';
+$username = 'John Doe <script>hack</script>';
+
+$avatarImage = Html::el('img')->src($avatarUrl)->width(16);
+echo Escape::html($avatarImage, ' ', $username);
+
+// <img src="http:/example.com/avatar.png" width="16"> John Doe &lt;script&gt;hack&lt;/script&gt;
+```
 
 ## Output without any escaping
 

--- a/src/Escape.php
+++ b/src/Escape.php
@@ -19,18 +19,25 @@ use RuntimeException;
 class Escape
 {
     /**
-     * Escapes string for use everywhere inside HTML (except for comments).
-     * @param string|HtmlStringable|IHtmlString|mixed $data
+     * Escapes strings for use everywhere inside HTML (except for comments) and concatenate it to string.
+     * @param string|HtmlStringable|IHtmlString|mixed ...$data
      * @return string
      *
      * @link https://api.nette.org/2.4/source-Latte.Runtime.Filters.php.html#27-35
      */
-    public static function html($data): string
+    public static function html(...$data): string
     {
-        if ($data instanceof HtmlStringable || $data instanceof IHtmlString) {
-            return (string)$data;
+        $output = '';
+
+        foreach ($data as $item) {
+            if ($item instanceof HtmlStringable || $item instanceof IHtmlString) {
+                $output .= $item;
+            } else {
+                $output .= htmlspecialchars((string)$item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE);
+            }
         }
-        return htmlspecialchars((string)$data, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE);
+
+        return $output;
     }
 
     /**

--- a/tests/EscapeTest.php
+++ b/tests/EscapeTest.php
@@ -18,31 +18,40 @@ class EscapeTest extends TestCase
     public function getHtmlArgs(): array
     {
         return [
-            ['', null],
-            ['', ''],
-            ['1', 1],
-            ['string', 'string'],
-            ['&lt;br&gt;', '<br>'],
-            ['&lt; &amp; &apos; &quot; &gt;', '< & \' " >'],
-            ['&amp;quot;', '&quot;'],
-            ['`hello', '`hello'],
-            ["foo \u{FFFD} bar", "foo \u{D800} bar"], // invalid codepoint high surrogates
-            ["foo \u{FFFD}&quot; bar", "foo \xE3\x80\x22 bar"], // stripped UTF
-            ['Hello World', 'Hello World'],
-            ['Hello &lt;World&gt;', 'Hello <World>'],
-            ['&quot; &apos; &lt; &gt; &amp; �', "\" ' < > & \x8F"],
-            ['`hello`', '`hello`'],
-            ['` &lt;br&gt; `', '` <br> `'],
-            ['Foo<br>bar', Html::fromHtml('Foo<br>bar')]
+            ['', []],
+            ['', [null]],
+            ['', ['']],
+            ['1', [1]],
+            ['string', ['string']],
+            ['&lt;br&gt;', ['<br>']],
+            ['&lt; &amp; &apos; &quot; &gt;', ['< & \' " >']],
+            ['&amp;quot;', ['&quot;']],
+            ['`hello', ['`hello']],
+            ["foo \u{FFFD} bar", ["foo \u{D800} bar"]], // invalid codepoint high surrogates
+            ["foo \u{FFFD}&quot; bar", ["foo \xE3\x80\x22 bar"]], // stripped UTF
+            ['Hello World', ['Hello World']],
+            ['Hello &lt;World&gt;', ['Hello <World>']],
+            ['Hello World', [Html::fromText('Hello World')]],
+            ['Hello &lt;World&gt;', [Html::fromText('Hello <World>')]],
+            ['&quot; &apos; &lt; &gt; &amp; �', ["\" ' < > & \x8F"]],
+            ['`hello`', ['`hello`']],
+            ['` &lt;br&gt; `', ['` <br> `']],
+            ['Foo<br>bar', [Html::fromHtml('Foo<br>bar')]],
+            ['Foo&lt;br&gt;bar', [Html::fromText('Foo<br>bar')]],
+            ['Hello &lt;World&gt;Hello &lt;World&gt;', ['Hello <World>', 'Hello <World>']],
+            ['Hello &lt;World&gt;Hello <World>', ['Hello <World>', Html::fromHtml('Hello <World>')]],
+            ['Hello <World>Hello &lt;World&gt;', [Html::fromHtml('Hello <World>'), 'Hello <World>']],
+            ['Hello <World>Hello <World>', [Html::fromHtml('Hello <World>'), Html::fromHtml('Hello <World>')]],
         ];
     }
 
     /**
+     * @param array<string> $data
      * @dataProvider getHtmlArgs
      */
-    public function testHtml(string $expected, $data): void
+    public function testHtml(string $expected, array $data): void
     {
-        Assert::same($expected, Escape::html($data));
+        Assert::same($expected, Escape::html(...$data));
     }
 
     public function getHtmlAttrArgs(): array


### PR DESCRIPTION
When we get some values for output, maybe `Html`, maybe plaintext, this PR allow way to concatenate all of them safely.

Example of acquired variable:
```php
$html = Html::fromHtml('<b>Error:</b> Invalid value');
```

Allow simple concatenate different types of input:
```php
echo Escape::html($html, ' user: ', $_POST['firstname'], ' ', , $_POST['lastname']);
```

instead of non-comport concatenate:
```php
echo Escape::html($html) . ' user: ' . Escape::html($_POST['firstname']). ' ' . Escape::html($_POST['firstname']);
```