### PR TITLE
Update HTML filters

### DIFF
--- a/src/Escape.php
+++ b/src/Escape.php
@@ -50,9 +50,6 @@ class Escape
     public static function htmlAttr($data): string
     {
         $data = (string)$data;
-        if (strpos($data, '`') !== false && strpbrk($data, ' <>"\'') === false) {
-            $data .= ' '; // protection against innerHTML mXSS vulnerability nette/nette#1496
-        }
         return self::html($data);
     }
 

--- a/src/Escape.php
+++ b/src/Escape.php
@@ -58,6 +58,20 @@ class Escape
     }
 
     /**
+     * Escapes JSON data for use inside HTML attribute value (especially for data attributes).
+     * @param array|mixed $data
+     * @return string
+     */
+    public static function htmlJsonAttr($data): string
+    {
+        $json = json_encode(
+            $data,
+            JSON_HEX_AMP | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        );
+        return self::htmlAttr($json);
+    }
+
+    /**
      * Escapes string for use inside HTML attribute `href` or `src` which contains URL string.
      * @param string|mixed $data
      * @return string

--- a/src/Escape.php
+++ b/src/Escape.php
@@ -33,7 +33,9 @@ class Escape
             if ($item instanceof HtmlStringable || $item instanceof IHtmlString) {
                 $output .= $item;
             } else {
-                $output .= htmlspecialchars((string)$item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE);
+                $str = htmlspecialchars((string)$item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE);
+                $str = strtr($str, ['{{' => '{<!-- -->{', '{' => '&#123;']);
+                $output .= $str;
             }
         }
 
@@ -50,7 +52,9 @@ class Escape
     public static function htmlAttr($data): string
     {
         $data = (string)$data;
-        return self::html($data);
+        $data = htmlspecialchars($data, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8');
+        $data = str_replace('{', '&#123;', $data);
+        return $data;
     }
 
     /**

--- a/src/Escape.php
+++ b/src/Escape.php
@@ -19,7 +19,7 @@ use RuntimeException;
 class Escape
 {
     /**
-     * Escapes strings for use everywhere inside HTML (except for comments) and concatenate it to string.
+     * Escapes strings for use inside HTML text and concatenate it to string.
      * @param string|HtmlStringable|IHtmlString|mixed ...$data
      * @return string
      *
@@ -33,7 +33,7 @@ class Escape
             if ($item instanceof HtmlStringable || $item instanceof IHtmlString) {
                 $output .= $item;
             } else {
-                $str = htmlspecialchars((string)$item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE);
+                $str = htmlspecialchars((string)$item, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE, 'UTF-8');
                 $str = strtr($str, ['{{' => '{<!-- -->{', '{' => '&#123;']);
                 $output .= $str;
             }
@@ -173,13 +173,13 @@ class Escape
      *
      * @link https://api.nette.org/2.4/source-Latte.Runtime.Filters.php.html#_safeUrl
      */
-    public static function safeUrl($data, bool $warning = false):string
+    public static function safeUrl($data, bool $warning = false): string
     {
         if (preg_match('~^(?:(?:https?|ftp)://[^@]+(?:/.*)?|(?:mailto|tel|sms):.+|[/?#].*|[^:]+)$~Di', (string)$data)) {
             return (string)$data;
         }
 
-        if($warning) {
+        if ($warning) {
             trigger_error('URL was removed because is invalid or unsafe: ' . $data, E_USER_WARNING);
         }
 

--- a/src/Escape.php
+++ b/src/Escape.php
@@ -68,6 +68,11 @@ class Escape
             $data,
             JSON_HEX_AMP | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
         );
+
+        if ($json === false) {
+            throw new RuntimeException('Failed to encode JSON for HTML attribute: ' . json_last_error_msg());
+        }
+        
         return self::htmlAttr($json);
     }
 

--- a/tests/EscapeTest.php
+++ b/tests/EscapeTest.php
@@ -42,6 +42,7 @@ class EscapeTest extends TestCase
             ['Hello &lt;World&gt;Hello <World>', ['Hello <World>', Html::fromHtml('Hello <World>')]],
             ['Hello <World>Hello &lt;World&gt;', [Html::fromHtml('Hello <World>'), 'Hello <World>']],
             ['Hello <World>Hello <World>', [Html::fromHtml('Hello <World>'), Html::fromHtml('Hello <World>')]],
+            ['Hello {<!-- -->{my}} lord', ['Hello {{my}} lord']],
         ];
     }
 
@@ -63,7 +64,7 @@ class EscapeTest extends TestCase
             ['string', 'string'],
             ['&lt; &amp; &apos; &quot; &gt;', '< & \' " >'],
             ['&amp;quot;', '&quot;'],
-            ['`hello ', '`hello'],
+            ['`hello', '`hello'],
             ['`hello&quot;', '`hello"'],
             ['`hello&apos;', "`hello'"],
             ["foo \u{FFFD} bar", "foo \u{D800} bar"], // invalid codepoint high surrogates
@@ -71,10 +72,11 @@ class EscapeTest extends TestCase
             ['Hello World', 'Hello World'],
             ['Hello &lt;World&gt;', 'Hello <World>'],
             ['&quot; &apos; &lt; &gt; &amp; �', "\" ' < > & \x8F"],
-            ['`hello` ', '`hello`'],
-            ['``onmouseover=alert(1) ', '``onmouseover=alert(1)'],
+            ['`hello`', '`hello`'],
+            ['``onmouseover=alert(1)', '``onmouseover=alert(1)'],
             ['` &lt;br&gt; `', '` <br> `'],
-            ['Foo&lt;br&gt;bar', Html::fromHtml('Foo<br>bar')]
+            ['Foo&lt;br&gt;bar', Html::fromHtml('Foo<br>bar')],
+            ['Hello &#123;&#123;my}} lord', 'Hello {{my}} lord'],
         ];
     }
 
@@ -84,6 +86,31 @@ class EscapeTest extends TestCase
     public function testHtmlAttr(string $expected, $data): void
     {
         Assert::same($expected, Escape::htmlAttr($data));
+    }
+
+    public function getHtmlJsonAttrArgs(): array
+    {
+        return [
+            ['null', null],
+            ['&quot;&quot;', ''],
+            ['1', 1],
+            ['&quot;string&quot;', 'string'],
+            ['&quot;&lt;/tag&quot;', '</tag'],
+            ['&quot;\u2028 \u2029 ]]&gt; &lt;!&quot;', "\u{2028} \u{2029} ]]> <!"],
+            ['[0,1]', [0, 1]],
+            ['[&quot;0&quot;,&quot;1&quot;]', ['0', '1']],
+            ['&#123;&quot;a&quot;:&quot;0&quot;,&quot;b&quot;:&quot;1&quot;}', ['a' => '0', 'b' => '1']],
+            ['&#123;&quot;a&quot;:&quot;Hello &#123;&#123;my}} world&quot;,&quot;b&quot;:&quot;1&quot;}', ['a' => 'Hello {{my}} world', 'b' => '1']],
+            ['&quot;&lt;/script&gt;&quot;', '</script>'],
+        ];
+    }
+
+    /**
+     * @dataProvider getHtmlJsonAttrArgs
+     */
+    public function testHtmlJsonAttr($expected, $data): void
+    {
+        Assert::same($expected, Escape::htmlJsonAttr($data));
     }
 
     public function getHtmlHrefArgs(): array

--- a/tests/EscapeTest.php
+++ b/tests/EscapeTest.php
@@ -42,6 +42,7 @@ class EscapeTest extends TestCase
             ['Hello &lt;World&gt;Hello <World>', ['Hello <World>', Html::fromHtml('Hello <World>')]],
             ['Hello <World>Hello &lt;World&gt;', [Html::fromHtml('Hello <World>'), 'Hello <World>']],
             ['Hello <World>Hello <World>', [Html::fromHtml('Hello <World>'), Html::fromHtml('Hello <World>')]],
+            ['Hello &#123;my} lord', ['Hello {my} lord']],
             ['Hello {<!-- -->{my}} lord', ['Hello {{my}} lord']],
         ];
     }

--- a/tests/EscapeTest.php
+++ b/tests/EscapeTest.php
@@ -114,6 +114,15 @@ class EscapeTest extends TestCase
         Assert::same($expected, Escape::htmlJsonAttr($data));
     }
 
+    public function testInvalidHtmlJsonAttr(): void
+    {
+        $data = ['number' => NAN];
+
+        Assert::exception(static function () use ($data): void {
+            Escape::htmlJsonAttr($data);
+        }, RuntimeException::class, 'Failed to encode JSON for HTML attribute: Inf and NaN cannot be JSON encoded');
+    }
+
     public function getHtmlHrefArgs(): array
     {
         return [


### PR DESCRIPTION
Updates of escaping mechanismus:

- add `Escape::htmlJsonAttr()` to escape data serialized to HTML attribute,
- remove protection for innerHTML mXSS vulnerability (nette/nette#1496),
- improve compatibility with JS binding (syntax of `{{ variables }}` in JS templates)
- small improves